### PR TITLE
Makefile: Glob more possible tarball names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 all:
 	cd xapian-core && $(MAKE)
 distcheck:
-	cd xapian-core && $(MAKE) $@ && cp xapian-core*.tar.xz ..
+	cd xapian-core && $(MAKE) $@ && cp xapian*-core*.tar.xz ..
 install:
 	cd xapian-core && $(MAKE) $@
 


### PR DESCRIPTION
On jenkins, we want to use the tarball name xapian-1.3-core because
that's what the debian source package is named so that it doesn't
conflict with the older xapian-core package. Allow a little more freedom
in the distcheck copy up to allow this.
