### PR TITLE
Allow building with GCC ≥ 7

### DIFF
--- a/xapian-core/backends/dbfactory.cc
+++ b/xapian-core/backends/dbfactory.cc
@@ -495,6 +495,9 @@ WritableDatabase::WritableDatabase(const std::string &path, int flags, int block
 	}
 	// Fall through to first enabled case, so order the remaining cases
 	// by preference.
+#if defined(__GNUC__) && (__GNUC__ >= 7)
+        __attribute__((fallthrough));
+#endif
 #ifdef XAPIAN_HAS_CHERT_BACKEND
 	case DB_BACKEND_CHERT:
 	    internal.push_back(new ChertWritableDatabase(path, flags, block_size));


### PR DESCRIPTION
GCC 7.x enabled the 'implicit-fallthrough' warning when compiling C++,
and Xapian builds with a blanket -Werror when enabling maintainer mode.
This tripped up an implicit fallthrough in a switch block that does not
fall under the "whitelist" approach based on parsing the comments. For
these cases, GCC offers an escape hatch in the form of a compiler
attribute.