### PR TITLE
Don't package static library

### DIFF
--- a/debian/libxapian-1.3-dev.install
+++ b/debian/libxapian-1.3-dev.install
@@ -1,7 +1,6 @@
 usr/bin/xapian-config-1.3
 usr/include
 usr/lib/cmake/xapian/* usr/lib/cmake/xapian-1.3
-usr/lib/libxapian-1.3.a
 usr/lib/libxapian-1.3.la
 usr/lib/libxapian-1.3.so
 usr/share/aclocal

--- a/debian/libxapianVERSION-dev.install
+++ b/debian/libxapianVERSION-dev.install
@@ -1,7 +1,6 @@
 usr/bin/xapian-config-1.3
 usr/include
 usr/lib/cmake/xapian
-usr/lib/libxapian-1.3.a
 usr/lib/libxapian-1.3.la
 usr/lib/libxapian-1.3.so
 usr/share/aclocal


### PR DESCRIPTION
It's not used, and there's a pending change to endlessm/xapian-core
which will mean we no longer build it - the packaging will stop
working when that lands (but stopping packaging it first should be
fine).