### PR TITLE
Add explicit "all" target so "make" doesn't distcheck

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,7 +1,12 @@
+# Need an explicit default target so we don't "make distcheck" by default.
+all:
+	$(MAKE) -C xapian-core $@
+
 distcheck:
-	$(MAKE) -C xapian-core $@ && cp xapian-core/xapian*-core*.tar.xz .
+	$(MAKE) -C xapian-core $@
+	cp xapian-core/xapian*-core*.tar.xz .
 
 %:
 	$(MAKE) -C xapian-core $@
 
-.PHONY: distcheck
+.PHONY: all distcheck


### PR DESCRIPTION
This was causing jenkins to run "make distcheck" twice!