### PR TITLE
Wrap getaddrinfo() in a class

### DIFF
--- a/xapian-core/net/Makefile.mk
+++ b/xapian-core/net/Makefile.mk
@@ -7,6 +7,7 @@ noinst_HEADERS +=\
 	net/remotetcpserver.h\
 	net/replicatetcpclient.h\
 	net/replicatetcpserver.h\
+	net/resolver.h\
 	net/serialise.h\
 	net/serialise-error.h\
 	net/tcpclient.h\

--- a/xapian-core/net/resolver.h
+++ b/xapian-core/net/resolver.h
@@ -1,0 +1,128 @@
+/** @file resolver.h
+ * @brief Resolve hostnames and ip addresses
+ */
+/* Copyright (C) 2017 Olly Betts
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#ifndef XAPIAN_INCLUDED_RESOLVER_H
+#define XAPIAN_INCLUDED_RESOLVER_H
+
+#include <cstring>
+#include "safenetdb.h"
+#include "str.h"
+#include "xapian/error.h"
+
+using namespace std;
+
+class Resolver {
+    struct addrinfo* result = NULL;
+
+  public:
+    class const_iterator {
+	struct addrinfo* p;
+      public:
+	const_iterator(struct addrinfo* p_) : p(p_) { }
+
+	struct addrinfo& operator*() const {
+	   return *p;
+	}
+
+	void operator++() {
+	    p = p->ai_next;
+	}
+
+	const_iterator operator++(int) {
+	    struct addrinfo* old_p = p;
+	    operator++();
+	    return const_iterator(old_p);
+	}
+
+	bool operator==(const const_iterator& o) {
+	    return p == o.p;
+	}
+
+	bool operator!=(const const_iterator& o) {
+	    return !(*this == o);
+	}
+    };
+
+    Resolver(const std::string& host, int port, int flags = 0) {
+	// RFC 3493 has an extra sentence in its definition of
+	// AI_ADDRCONFIG which POSIX doesn't:
+	//
+	//   "The loopback address is not considered for this case as valid
+	//   as a configured address."
+	//
+	// Some platforms implement this version rather than POSIX (notably
+	// glibc on Linux).  Others implement POSIX (from looking at the
+	// man pages, these include FreeBSD 11.0).
+	//
+	// In most cases, this extra sentence is arguably helpful - e.g. it
+	// means that you won't get IPv6 addresses just because the system
+	// has IPv6 loopback (and similarly for IPv4).
+	//
+	// However, it behaves unhelpfully if the *only* interface
+	// configured is loopback - in this situation, AI_ADDRCONFIG means
+	// that you won't get an IPv4 address (as there's no IPv4 address
+	// configured ignoring loopback) and you won't get an IPv5 address
+	// (as there's no IPv6 address configured ignoring loopback).
+	//
+	// It's generally rare that systems with only loopback would want
+	// to use the remote backend, but a real example is testsuites
+	// (including our own) running on autobuilders which deliberately
+	// close off network access.
+	//
+	// To allow such cases to work on Linux (and other platforms which
+	// follow the RFC rather than POSIX in this detail) we avoid using
+	// AI_ADDRCONFIG for 127.0.0.1, ::1 and localhost.  There are
+	// other ways to write these IP addresses and other hostnames may
+	// map onto them, but this just needs to work for the standard
+	// cases which a testsuite might use.
+	if (host != "::1" && host != "127.0.0.1" && host != "localhost") {
+	    flags |= AI_ADDRCONFIG;
+	}
+	flags |= AI_NUMERICSERV;
+
+	struct addrinfo hints;
+	std::memset(&hints, 0, sizeof(struct addrinfo));
+	hints.ai_family = AF_INET;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_flags = flags;
+	hints.ai_protocol = 0;
+
+	const char * node = host.empty() ? NULL : host.c_str();
+	int r = getaddrinfo(node, str(port).c_str(), &hints, &result);
+	if (r != 0) {
+	    throw Xapian::NetworkError("Couldn't resolve host " + host,
+				       eai_to_xapian(r));
+	}
+    }
+
+    ~Resolver() {
+	if (result) freeaddrinfo(result);
+    }
+
+    const_iterator begin() const {
+	return const_iterator(result);
+    }
+
+    const_iterator end() const {
+	return const_iterator(NULL);
+    }
+};
+
+#endif // XAPIAN_INCLUDED_RESOLVER_H

--- a/xapian-core/net/tcpclient.cc
+++ b/xapian-core/net/tcpclient.cc
@@ -2,7 +2,7 @@
  *
  * Copyright 1999,2000,2001 BrightStation PLC
  * Copyright 2002 Ananova Ltd
- * Copyright 2004,2005,2006,2007,2008,2010,2012,2013,2015 Olly Betts
+ * Copyright 2004,2005,2006,2007,2008,2010,2012,2013,2015,2017 Olly Betts
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -23,6 +23,7 @@
 #include <config.h>
 
 #include "remoteconnection.h"
+#include "resolver.h"
 #include "str.h"
 #include "tcpclient.h"
 #include <xapian/error.h>
@@ -48,25 +49,11 @@ int
 TcpClient::open_socket(const std::string & hostname, int port,
 		       double timeout_connect, bool tcp_nodelay)
 {
-    struct addrinfo hints;
-    memset(&hints, 0, sizeof(struct addrinfo));
-    hints.ai_family = AF_INET;
-    hints.ai_socktype = SOCK_STREAM;
-    hints.ai_flags = AI_ADDRCONFIG | AI_NUMERICSERV;
-    hints.ai_protocol = 0;
-
-    struct addrinfo *result;
-    int s = getaddrinfo(hostname.c_str(), str(port).c_str(), &hints, &result);
-    if (s != 0) {
-	throw Xapian::NetworkError("Couldn't resolve host " + hostname,
-				   eai_to_xapian(s));
-    }
-
-    int connect_errno = 0;
     int socketfd = -1;
-    for (struct addrinfo * rp = result; rp != NULL; rp = rp->ai_next) {
-	int socktype = rp->ai_socktype | SOCK_CLOEXEC;
-	int fd = socket(rp->ai_family, socktype, rp->ai_protocol);
+    int connect_errno = 0;
+    for (auto&& r : Resolver(hostname, port)) {
+	int socktype = r.ai_socktype | SOCK_CLOEXEC;
+	int fd = socket(r.ai_family, socktype, r.ai_protocol);
 	if (fd == -1)
 	    continue;
 
@@ -92,7 +79,6 @@ TcpClient::open_socket(const std::string & hostname, int port,
 	if (rc < 0) {
 	    int saved_errno = socket_errno(); // note down in case close hits an error
 	    close_fd_or_socket(fd);
-	    freeaddrinfo(result);
 	    throw Xapian::NetworkError("Couldn't set " FLAG_NAME, saved_errno);
 #undef FLAG_NAME
 	}
@@ -107,12 +93,11 @@ TcpClient::open_socket(const std::string & hostname, int port,
 			   sizeof(optval)) < 0) {
 		int saved_errno = socket_errno(); // note down in case close hits an error
 		close_fd_or_socket(fd);
-		freeaddrinfo(result);
 		throw Xapian::NetworkError("Couldn't set TCP_NODELAY", saved_errno);
 	    }
 	}
 
-	int retval = connect(fd, rp->ai_addr, rp->ai_addrlen);
+	int retval = connect(fd, r.ai_addr, r.ai_addrlen);
 	if (retval == 0) {
 	    socketfd = fd;
 	    break;
@@ -141,7 +126,6 @@ TcpClient::open_socket(const std::string & hostname, int port,
 	    if (retval <= 0) {
 		int saved_errno = errno;
 		close_fd_or_socket(fd);
-		freeaddrinfo(result);
 		if (retval < 0)
 		    throw Xapian::NetworkError("Couldn't connect (select() on socket failed)",
 					       saved_errno);
@@ -159,7 +143,6 @@ TcpClient::open_socket(const std::string & hostname, int port,
 	    if (retval < 0) {
 		int saved_errno = socket_errno(); // note down in case close hits an error
 		close_fd_or_socket(fd);
-		freeaddrinfo(result);
 		throw Xapian::NetworkError("Couldn't get socket options", saved_errno);
 	    }
 	    if (err == 0) {
@@ -178,8 +161,6 @@ TcpClient::open_socket(const std::string & hostname, int port,
 	// Failed to connect.
 	CLOSESOCKET(fd);
     }
-
-    freeaddrinfo(result);
 
     if (socketfd == -1) {
 	throw Xapian::NetworkError("Couldn't connect", connect_errno);


### PR DESCRIPTION
Upstream patch.

This allows us to fairly cleanly workaround the unhelpful semantics
of AI_ADDRCONFIG on platforms which follow the old RFC instead of
POSIX - if only loopback networking is configured, localhost won't
resolve by name or IP address, which causes testsuites using the
remote backend over localhost to fail in auto-build environments
which deliberately disable networking during builds.

The workaround implemented is to check if the hostname is "::1",
"127.0.0.1" or "localhost" and disable AI_ADDRCONFIG for these.
This doesn't catch all possible ways to specify localhost, but
should catch all the ways these might be specified in a testsuite.

Fixes https://bugs.debian.org/853107, reported by Daniel Schepler
and the root cause uncovered by James Clarke.

https://phabricator.endlessm.com/T17307