### PR TITLE
Install pkg-config file in the dev package

### DIFF
--- a/debian/libxapian-1.3-dev.install
+++ b/debian/libxapian-1.3-dev.install
@@ -3,5 +3,6 @@ usr/include
 usr/lib/cmake/xapian/* usr/lib/cmake/xapian-1.3
 usr/lib/libxapian-1.3.la
 usr/lib/libxapian-1.3.so
+usr/lib/pkgconfig/xapian-core-1.3.pc
 usr/share/aclocal
 usr/share/man/man1/xapian-config-1.3.1


### PR DESCRIPTION
We're missing the pkg-config file, which is used by dependent projects like xapian-glib.