### PR TITLE
Change libxapian-1.3 priority from important to optional

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Vcs-svn: svn://svn.xapian.org/xapian/trunk/xapian-core
 Package: libxapian-1.3
 Architecture: any
 Section: libs
-Priority: important
+Priority: optional
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Suggests: xapian-1.3-tools
 Description: Search engine library


### PR DESCRIPTION
This was causing it to be pulled into the OS during the initial
bootstrapping phase. If it needs to be pulled into the OS (which it
doesn't anymore), then something will bring it in as a dependency.